### PR TITLE
Add compound adder doc. Make ripple-carry adder carry input optional.…

### DIFF
--- a/doc/components/adder.md
+++ b/doc/components/adder.md
@@ -6,6 +6,7 @@ ROHD-HCL provides a set of adder modules to get the sum from a pair of Logic. As
 - [Parallel Prefix Adder](#parallel-prefix-adder)
 - [One's Complement Adder Subtractor](#ones-complement-adder-subtractor)
 - [Sign Magnitude Adder](#sign-magnitude-adder)
+- [Compound Adder](#compound-adder)
 
 ## Ripple Carry Adder
 
@@ -102,3 +103,30 @@ Here is an example of instantiating a `SignMagnitudeAdder`:
 
     print('${sum.value.toBigInt()}');
 ```
+## Compound Adder
+
+A compound carry adder is a digital circuit used for binary addition. It produces sum and sum+1 outputs.
+A trivial compund adder component [`TrivialCompoundAdder`](https://intel.github.io/rohd-hcl/rohd_hcl/TrivialCompoundAdder-class.html) doesnt use any RTL code optimization.
+Carry-select adder-based compund adder [`CarrySelectCompoundAdder`](https://intel.github.io/rohd-hcl/rohd_hcl/CarrySelectCompoundAdder-class.html) uses carry-select adder as a basis. Like a carry-select adder it consists of a multiple blocks of two ripple-carry adders (https://en.wikipedia.org/wiki/Carry-select_adder). But the first block has two ripple-carry adders and two separate carry-propagate chains are used to select sum and sum+1 output bits. sum selecting chain starts from carry input 'zero' driven block and sum+1 selecting chain starts from carry input 'one' driven block.
+The delay of the adder is defined by combination ripple-carry adder and accumulated carry-select chain delay. 
+
+The [`CarrySelectCompoundAdder`](https://intel.github.io/rohd-hcl/rohd_hcl/CarrySelectCompoundAdder-class.html) module in ROHD-HCL accept input `Logic`s a and b as the input pin and the name of the module `name`. Note that the width of the inputs must be the same or a `RohdHclException` will be thrown.
+Compound adder generator provides two alogithms for splitting adder into ripple-carry blocks. [CarrySelectCompoundAdder.splitSelectAdderAlgorithm4Bit] algoritm splits adder into blocks of 4-bit ripple-carry adders with the first one width adjusted down. [CarrySelectCompoundAdder.splitSelectAdderAlgorithmSingleBlock] algorithm generates only one block of full bitwidth of the adder. Input List<int> Function(int adderFullWidth) [widthGen] should be used to specify custom adder splitting algorithm that return a list of sub-adders width. The default one is [CarrySelectCompoundAdder.splitSelectAdderAlgorithmSingleBlock].
+
+An example is shown below to add two inputs of signals that have 8-bits of width.
+
+```dart
+final a = Logic(name: 'a', width: 8);
+final b = Logic(name: 'b', width: 8);
+
+a.put(5);
+b.put(5);
+
+final rippleCarryAdder = CarrySelectCompoundAdder(a, b);
+final sum = rippleCarryAdder.sum;
+final sum1 = rippleCarryAdder.sum1;
+
+final rippleCarryAdder4BitBlock = CarrySelectCompoundAdder(a, b,
+        widthGen: CarrySelectCompoundAdder.splitSelectAdderAlgorithm4Bit);
+```
+

--- a/lib/src/arithmetic/compound_adder.dart
+++ b/lib/src/arithmetic/compound_adder.dart
@@ -13,7 +13,7 @@ import 'package:rohd_hcl/rohd_hcl.dart';
 
 /// An abstract class for all compound adder module implementations.
 abstract class CompoundAdder extends Adder {
-  /// The addition results (+1) in 2s complement form as [sum1]
+  /// The addition result [sum] + 1 in 2s complement form as [sum1]
   Logic get sum1 => output('sum1');
 
   /// Takes in input [a] and input [b] and return the [sum] of the addition
@@ -28,9 +28,10 @@ abstract class CompoundAdder extends Adder {
 }
 
 /// A trivial compound adder.
-class MockCompoundAdder extends CompoundAdder {
+class TrivialCompoundAdder extends CompoundAdder {
   /// Constructs a [CompoundAdder].
-  MockCompoundAdder(super.a, super.b, {super.name = 'mock_compound_adder'}) {
+  TrivialCompoundAdder(super.a, super.b,
+      {super.name = 'trivial_compound_adder'}) {
     sum <= a.zeroExtend(a.width + 1) + b.zeroExtend(b.width + 1);
     sum1 <= sum + 1;
   }
@@ -90,13 +91,13 @@ class CarrySelectCompoundAdder extends CompoundAdder {
       }
       final blockA = Logic(name: 'block_${i}_a', width: blockWidth);
       final blockB = Logic(name: 'block_${i}_b', width: blockWidth);
-      blockA <= a.slice(blockStartIdx + blockWidth - 1, blockStartIdx);
-      blockB <= b.slice(blockStartIdx + blockWidth - 1, blockStartIdx);
+      blockA <= a.getRange(blockStartIdx, blockStartIdx + blockWidth);
+      blockB <= b.getRange(blockStartIdx, blockStartIdx + blockWidth);
       // Build ripple-carry adders for 0 and 1 carryin values
-      final fullAdder0 =
-          RippleCarryAdderC(blockA, blockB, Const(0), name: 'block0_${i}');
-      final fullAdder1 =
-          RippleCarryAdderC(blockA, blockB, Const(1), name: 'block1_${i}');
+      final fullAdder0 = RippleCarryAdder(blockA, blockB,
+          carryIn: Const(0), name: 'block0_$i');
+      final fullAdder1 = RippleCarryAdder(blockA, blockB,
+          carryIn: Const(1), name: 'block1_$i');
       for (var bitIdx = 0; bitIdx < blockWidth; ++bitIdx) {
         if (i == 0) {
           // connect directly to respective sum output bit

--- a/lib/src/arithmetic/ripple_carry_adder.dart
+++ b/lib/src/arithmetic/ripple_carry_adder.dart
@@ -18,27 +18,16 @@ import 'package:rohd_hcl/rohd_hcl.dart';
 /// adder sequentially adds corresponding bits of two binary numbers.
 class RippleCarryAdder extends Adder {
   /// Constructs an n-bit adder based on inputs List of inputs.
-  RippleCarryAdder(super.a, super.b, {super.name = 'ripple_carry_adder'}) {
-    final adder = RippleCarryAdderC(a, b, Const(0));
-    sum <= adder.sum;
-  }
-}
-
-/// An [RippleCarryAdderC] is a digital circuit used for binary addition with
-/// exposed carry signals.
-/// It consists of a series of full adders connected in a chain, with the carry
-/// output of each adder linked to the carry input of the next one. Starting
-/// from the least significant bit (LSB) to most significant bit (MSB), the
-/// adder sequentially adds corresponding bits of two binary numbers.
-class RippleCarryAdderC extends Adder {
-  /// Constructs an n-bit adder based on inputs List of inputs.
-  RippleCarryAdderC(super.a, super.b, Logic carryIn,
-      {super.name = 'ripple_carry_adder_carry_in'}) {
-    carryIn = addInput('carry_in', carryIn, width: carryIn.width);
+  RippleCarryAdder(super.a, super.b,
+      {Logic? carryIn, super.name = 'ripple_carry_adder_carry_in'}) {
+    if (carryIn != null) {
+      carryIn = addInput('carry_in', carryIn, width: carryIn.width);
+    }
     Logic? carry;
     final sumList = <Logic>[];
     for (var i = 0; i < a.width; i++) {
-      final fullAdder = FullAdder(a: a[i], b: b[i], carryIn: carry ?? carryIn);
+      final fullAdder =
+          FullAdder(a: a[i], b: b[i], carryIn: carry ?? (carryIn ?? Const(0)));
 
       carry = fullAdder.carryOut;
       sumList.add(fullAdder.sum);

--- a/test/arithmetic/compound_adder_test.dart
+++ b/test/arithmetic/compound_adder_test.dart
@@ -22,7 +22,7 @@ void checkCompoundAdder(CompoundAdder adder, LogicValue av, LogicValue bv) {
   adder.b.put(bv);
 
   expect(adder.sum.value.toBigInt(), equals(aB + bB));
-  expect(adder.sum1.value.toBigInt(), equals(aB + bB + BigInt.from(1)));
+  expect(adder.sum1.value.toBigInt(), equals(aB + bB + BigInt.one));
 }
 
 void testExhaustive(int n, CompoundAdder Function(Logic a, Logic b) fn) {
@@ -50,7 +50,7 @@ void main() {
     await Simulator.reset();
   });
   group('exhaustive', () {
-    testExhaustive(4, MockCompoundAdder.new);
+    testExhaustive(4, TrivialCompoundAdder.new);
     testExhaustive(4, CarrySelectCompoundAdder.new);
   });
   test('trivial compound adder test', () async {

--- a/test/arithmetic/ripple_carry_adder_test.dart
+++ b/test/arithmetic/ripple_carry_adder_test.dart
@@ -115,7 +115,7 @@ void main() {
       final b = Logic(name: 'b', width: 16);
       final ci = Logic(name: 'carry_in');
 
-      expect(() => RippleCarryAdderC(a, b, ci),
+      expect(() => RippleCarryAdder(a, b, carryIn: ci),
           throwsA(const TypeMatcher<RohdHclException>()));
     });
 
@@ -132,7 +132,7 @@ void main() {
       b.put(lvB);
       ci.put(lvC);
 
-      final rippleCarryAdder = RippleCarryAdderC(a, b, ci);
+      final rippleCarryAdder = RippleCarryAdder(a, b, carryIn: ci);
       await rippleCarryAdder.build();
 
       expect(rippleCarryAdder.sum.value.toInt(), equals(lvA + lvB + lvC));
@@ -143,7 +143,7 @@ void main() {
       final b = Logic(name: 'b', width: 10)..put(0);
       final carryIn = Logic(name: 'carry_in')..put(0);
 
-      final rippleCarryAdder = RippleCarryAdderC(a, b, carryIn);
+      final rippleCarryAdder = RippleCarryAdder(a, b, carryIn: carryIn);
       await rippleCarryAdder.build();
 
       expect(rippleCarryAdder.sum.value.toInt(), equals(0));
@@ -156,7 +156,7 @@ void main() {
       final b = Logic(name: 'b', width: 10)..put(0);
       final carryIn = Logic(name: 'carry_in')..put(0);
 
-      final rippleCarryAdder = RippleCarryAdderC(a, b, carryIn);
+      final rippleCarryAdder = RippleCarryAdder(a, b, carryIn: carryIn);
       await rippleCarryAdder.build();
 
       expect(rippleCarryAdder.sum.value.toInt(), equals(valA));
@@ -167,7 +167,7 @@ void main() {
       final b = Logic(name: 'b', width: 10);
       final carryIn = Logic(name: 'carry_in');
 
-      final rippleCarryAdder = RippleCarryAdderC(a, b, carryIn);
+      final rippleCarryAdder = RippleCarryAdder(a, b, carryIn: carryIn);
       await rippleCarryAdder.build();
 
       final rand = Random(5);
@@ -189,7 +189,7 @@ void main() {
       final b = Logic(name: 'b', width: widthLength)..put(1 << widthLength - 1);
       final carryIn = Logic(name: 'carry_in')..put(1);
 
-      final rippleCarryAdder = RippleCarryAdderC(a, b, carryIn);
+      final rippleCarryAdder = RippleCarryAdder(a, b, carryIn: carryIn);
       await rippleCarryAdder.build();
 
       expect(rippleCarryAdder.sum.value.toInt(), (1 << a.width) + 1);
@@ -204,11 +204,11 @@ void main() {
       final b = Logic(name: 'b', width: widthLength)..put(1 << widthLength - 1);
       final carryIn = Logic(name: 'carry_in')..put(1);
 
-      final rippleCarryAdder = RippleCarryAdderC(a, b, carryIn);
+      final rippleCarryAdder = RippleCarryAdder(a, b, carryIn: carryIn);
       await rippleCarryAdder.build();
 
       expect(rippleCarryAdder.sum.value.toBigInt(),
-          (BigInt.one << a.width) + BigInt.from(1));
+          (BigInt.one << a.width) + BigInt.one);
       expect(rippleCarryAdder.sum.value.width, a.width + 1);
       expect(rippleCarryAdder.sum.value[widthLength], equals(LogicValue.one));
     });


### PR DESCRIPTION
… Remove ripple-carry adder with required carry input.

<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

<!-- Description of changes, and motivation for adding them. -->

## Related Issue(s)

<!-- If there are any issues related to this PR, please link to the issues here. -->

## Testing

<!-- Please describe how you tested your changes. -->

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

<!-- Answer here. -->

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

<!-- Answer here. -->
